### PR TITLE
Add support for NVIDIA GPU accelerated transcoding

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -315,6 +315,7 @@ func (s *Stream) transcode(startId int) {
 		scale = fmt.Sprintf("scale_vaapi=w=%d:h=%d:force_original_aspect_ratio=decrease", s.width, s.height)
 	} else if CV == "h264_nvenc" {
                 // NVENC
+		format = "format=nv12|cuda,hwupload"
 		scale = fmt.Sprintf("scale_cuda=w=%d:h=%d:force_original_aspect_ratio=decrease:passthrough=0", s.width, s.height)
         } else {
 		// x264
@@ -331,7 +332,7 @@ func (s *Stream) transcode(startId int) {
 		if CV == "h264_nvenc" {
 			// Due to a bug(?) in NVENC, passthrough=0 must be set
 			args = append(args, []string{
-                                "-vf", "scale_cuda=passthrough=0",
+                                "-vf", fmt.Sprintf("%s,%s", format, "scale_cuda=passthrough=0"),
                         }...)
                 } else {
                         args = append(args, []string{
@@ -339,17 +340,8 @@ func (s *Stream) transcode(startId int) {
                         }...)
                 }
 	} else {
-		if CV == "h264_nvenc" {
-                        args = append(args, []string{
-                                "-vf", scale,
-                        }...)
-                } else {
-                        args = append(args, []string{
-                                "-vf", fmt.Sprintf("%s,%s", format, scale),
-                        }...)
-                }
-                // Common arguments
-                args = append(args, []string{
+		args = append(args, []string{
+			"-vf", fmt.Sprintf("%s,%s", format, scale),
                         "-maxrate", fmt.Sprintf("%d", s.bitrate),
                         "-bufsize", fmt.Sprintf("%d", s.bitrate*2),
                 }...)


### PR DESCRIPTION
An initial proposal  for adding a transcoding profile using NVENC.

Tested and working (with a slight issue) using the following setup:
- Proxmox LXC -container (Debian Bullseye) with Nextcloud 24.0.5
- Latest version of Memories from Nextcloud apps (as of 24.11.2022)
- GeForce GTX 1060 3gb GPU (passthrough from host)
- FFMpeg version N-109225-g1ff9c07fa6 (built from source)
- Firefox 106.0.5 64bit

ONE ISSUE: The automatic quality option doesn't really work too well. After playing the first chunk of the video the playback stop for quite a while (I think it's when the stream server is changing to a higher quality). This seems odd as the GPU should be more than up to the task of transcoding anything up to 4k (and beyond) in real time. It's as if the stream server restarts the transcoding too late?

I'm very unfamiliar with FFMpeg and couldn't get any reasonable video output with CPU processing so I'm quite uncertain if this is how it's supposed to work with Memories or if there's still some FFMpeg option that I'm missing.